### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/iwebpp.io-v2.js
+++ b/lib/iwebpp.io-v2.js
@@ -18,7 +18,7 @@ var eventEmitter = require('events').EventEmitter,
 var MSGPACK = require('msgpack-js');
 
 // UUID generator
-var UUID = require('node-uuid');
+var UUID = require('uuid');
 
 // p2p stream websocket library
 ///var WebSocket = require('wspp');

--- a/lib/iwebpp.io.js
+++ b/lib/iwebpp.io.js
@@ -18,7 +18,7 @@ var eventEmitter = require('events').EventEmitter,
 var MSGPACK = require('msgpack-js');
 
 // UUID generator
-var UUID = require('node-uuid');
+var UUID = require('uuid');
 
 // p2p stream websocket library
 var WebSocket = require('wspp');

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
   },
   "main": "./index.js",
   "dependencies": {
-    "wspp": "0.7.1",
     "msgpack-js": "0.3.0",
-    "node-uuid": "1.4.2",
+    "node-sws": "1.1.x",
     "siphash": "1.0.x",
-    "node-sws": "1.1.x"
+    "uuid": "^3.0.0",
+    "wspp": "0.7.1"
   }
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.